### PR TITLE
Feat - Round results

### DIFF
--- a/.json/commands.json
+++ b/.json/commands.json
@@ -30,6 +30,7 @@
     "params": ["-w: Learned weigth file"],
     "optionalParams": [
       "-o: Output file path",
+      "-r: Round to binary results",
       "-s: Save results file path"
     ]
   }

--- a/README.txt
+++ b/README.txt
@@ -39,6 +39,8 @@ EXAMPLE OF USAGE:
     Example:
       1 0
 
+  - Optionally add parameter -r to round results to binary values
+
   - Run the multilayer perceptron:
     'python main.py --run -w=learning_file_path.json'
     You can use the optional output param to only print your desired values:

--- a/libraries/command_handler.py
+++ b/libraries/command_handler.py
@@ -4,11 +4,23 @@ from shutil import copyfile
 from multilayer_perceptron import learningProcess, getY2
 
 # Constants
-COMMAND_HELP = '--help'
-COMMAND_INPUT = '--input'
-COMMAND_OUTPUT = '--output'
-COMMAND_LEARN = '--learn'
-COMMAND_RUN = '--run'
+CMD_HELP = '--help'
+CMD_INPUT = '--input'
+CMD_LEARN = '--learn'
+CMD_OUTPUT = '--output'
+CMD_RUN = '--run'
+
+CONST_ALPHA = 'alpha'
+CONST_MAX_ERR = 'maxError'
+
+PARAM_ALPHA = 'a'
+PARAM_FILE = 'f'
+PARAM_INPUT = 'i'
+PARAM_MAX_ERR = 'm'
+PARAM_OUTPUT = 'o'
+PARAM_ROUND = 'r'
+PARAM_SAVE = 's'
+PARAM_WEIGHTS = 'w'
 
 # Validate that user's input params have the required ones
 def _validateMandatoryParameters(mandatoryParams, inputParams, message):
@@ -95,67 +107,68 @@ def _runCommandHelp(parameters):
 
 # Run command input
 def _runCommandInput(parameters):
-  _validateMandatoryParameters(['f'], parameters,
+  _validateMandatoryParameters([PARAM_FILE], parameters,
     '--input needs parameter -f for the generated input file\'s name')
-  _generateInputFile(parameters['f'])
+  _generateInputFile(parameters[PARAM_FILE])
 
 # Run command output
 def _runCommandOutput(parameters):
-  _validateMandatoryParameters(['f'], parameters,
+  _validateMandatoryParameters([PARAM_FILE], parameters,
     '--output needs parameter -f for the generated output file\'s name')
-  _generateOutputFile(parameters['f'])
+  _generateOutputFile(parameters[PARAM_FILE])
 
 # Run command learn
 def _runCommandLearn(parameters):
-  _validateMandatoryParameters(['i', 'w'], parameters,
+  _validateMandatoryParameters([PARAM_INPUT, PARAM_WEIGHTS], parameters,
     '--learn needs parameters -i and -w to get inputs and save learning')
   constants_file = open('.json/constants.json', 'r')
   constants = loads(constants_file.read())
   constants_file.close()
 
-  (x, d) = _readInputFile(parameters['i'])
-  alpha = constants['alpha']
-  maxError = constants['maxError']
-  if 'a' in parameters:
-    alpha = float(parameters['a'])
-  if 'm' in parameters:
-    maxError = float(parameters['m'])
+  (x, d) = _readInputFile(parameters[PARAM_INPUT])
+  alpha = constants[CONST_ALPHA]
+  maxError = constants[CONST_MAX_ERR]
+  if PARAM_ALPHA in parameters:
+    alpha = float(parameters[PARAM_ALPHA])
+  if PARAM_MAX_ERR in parameters:
+    maxError = float(parameters[PARAM_WEIGHTS])
 
-  learningFile = open(parameters['w'], 'w')
+  learningFile = open(parameters[PARAM_WEIGHTS], 'w')
   learningFile.write(dumps(learningProcess(x, d, alpha, maxError)))
   learningFile.close()
 
 # Run command run
 def _runCommandRun(parameters):
-  _validateMandatoryParameters(['w'], parameters,
+  _validateMandatoryParameters([PARAM_WEIGHTS], parameters,
     '--run needs parameter -o to get learned weights')
-  learningFile = open(parameters['w'], 'r')
+  learningFile = open(parameters[PARAM_WEIGHTS], 'r')
   (n, m, l, wh, wo) = loads(learningFile.read())
   learningFile.close()
 
   x2 = []
-  if 'o' in parameters:
-    x2 = _readOutputFile(parameters['o'])
+  if PARAM_OUTPUT in parameters:
+    x2 = _readOutputFile(parameters[PARAM_OUTPUT])
   else:
     x2 = list(product([False, True], repeat=n))
 
-  results = '\n'.join([r for r in getY2(x2, n, m, l, wh, wo, True)])
+  results = getY2(x2, n, m, l, wh, wo, PARAM_ROUND in parameters, True)
+  resultString = '\n'.join([r for r in results])
 
-  if 's' in parameters:
-    learningFile = open(parameters['s'], 'w')
-    learningFile.write('# Requested results running ' + parameters['w'] + \
-      ' network\n')
-    learningFile.write(results)
+  if PARAM_SAVE in parameters:
+    learningFile = open(parameters[PARAM_SAVE], 'w')
+    learningFile.write('# Requested results running ' + \
+      parameters[PARAM_WEIGHTS] + ' network\n')
+    learningFile.write(resultString)
     learningFile.close()
   else:
-    print results
+    print resultString
 
 # Map received command with it's function
 def runCommand(command, parameters):
   {
-    COMMAND_HELP: _runCommandHelp,
-    COMMAND_INPUT: _runCommandInput,
-    COMMAND_OUTPUT: _runCommandOutput,
-    COMMAND_LEARN: _runCommandLearn,
-    COMMAND_RUN: _runCommandRun
+    CMD_HELP: _runCommandHelp,
+    CMD_INPUT: _runCommandInput,
+    CMD_OUTPUT: _runCommandOutput,
+    CMD_LEARN: _runCommandLearn,
+    CMD_RUN: _runCommandRun
   }[command](parameters)

--- a/libraries/multilayer_perceptron.py
+++ b/libraries/multilayer_perceptron.py
@@ -51,9 +51,10 @@ def _activationFunction(net):
 def _getYh(x, wh, n, p, l):
   return [_activationFunction(_getNeth(x, wh, n, p, j)) for j in range(l)]
 
-# Calculate the 'y' of a learning pattern given its 'y h' and weights
-def _getY(yh, wo, l, m):
-  return [_activationFunction(_getNeto(yh, wo, l, k)) for k in range(m)]
+# Calculate the 'y' of a learning pattern, can round with rnd
+def _getY(yh, wo, l, m, rnd = False):
+  y = [_activationFunction(_getNeto(yh, wo, l, k)) for k in range(m)]
+  return y if not rnd else [int(round(v)) for v in y]
 
 # Calculate the correct weigths to pass all learning patterns
 def learningProcess(x, d, alpha, maxError):
@@ -83,7 +84,7 @@ def _toString(x2, y2):
   return [' '.join([str(int(b)) for b in x2[p]]) +
     ' | ' + ' '.join([str(v) for v in r]) for p, r in zip(range(len(x2)), y2)]
 
-# Calculate 'y2' given 'x2', 'wh', 'wo' and all the lengths
-def getY2(x2, n, m, l, wh, wo, string = False):
-  y2 = [_getY(_getYh(x2, wh, n, p, l), wo, l, m) for p in range(len(x2))]
-  return _toString(x2, y2) if string else y2
+# Calculate 'y2' given all params, can round and stringify
+def getY2(x2, n, m, l, wh, wo, rnd = False, toStr = False):
+  y2 = [_getY(_getYh(x2, wh, n, p, l), wo, l, m, rnd) for p in range(len(x2))]
+  return _toString(x2, y2) if toStr else y2


### PR DESCRIPTION
# What does this PR do

- Add new optional param to `--run`: `r` to round results to binary values.

## Example
`python main.py --run -w=weights.txt -o=output.txt`
Prints:
`0 0 | 0.019222830548`

`python main.py --run -w=weights.txt -o=output.txt -r`
Prints:
`0 0 | 0`

## Solves
Issue https://github.com/luixlive/multilayer_perceptron/issues/6